### PR TITLE
fix get policy name from ruleID

### DIFF
--- a/pkg/controller/policy/cache/rule.go
+++ b/pkg/controller/policy/cache/rule.go
@@ -215,7 +215,7 @@ func groupIndexFunc(obj interface{}) ([]string, error) {
 
 func policyIndexFunc(obj interface{}) ([]string, error) {
 	rule := obj.(*CompleteRule)
-	policyName := strings.Split(rule.RuleID, "/")[1]
+	policyName := strings.Split(rule.RuleID, "/")[0]
 	return []string{policyName}, nil
 }
 


### PR DESCRIPTION
policyIndexFunc get wrong policy name from ruleID, CompleteRules wouldn't delete after policy delete.